### PR TITLE
Spike on escaping the URL used in a watermark filter

### DIFF
--- a/lib/ruby-thumbor.rb
+++ b/lib/ruby-thumbor.rb
@@ -99,7 +99,19 @@ module Thumbor
             if options[:filters] && !options[:filters].empty?
               filter_parts = []
               options[:filters].each do |filter|
-                filter_parts.push(filter)
+                if 'watermark' == filter[0].to_s
+                    # avoid String#split because there could be an unknown
+                    # number of commas in the url portion
+                    md = filter[1].match(/(.*),([^,]*),([^,]*),([^,]*)/)
+                    watermark_url, x_pos, y_pos, alpha = $1, $2, $3, $4
+
+                    # escape the URL otherwise certain characters like '?' could interfere with the containing URL
+                    watermark_url = CGI::escape(watermark_url)
+
+                    filter_parts.push([filter[0], "#{watermark_url},#{x_pos},#{y_pos},#{alpha}"])
+                else
+                    filter_parts.push(filter)
+                end
               end
 
               url_parts.push("filters:#{ filter_parts.join(':') }")

--- a/spec/ruby-thumbor_spec.rb
+++ b/spec/ruby-thumbor_spec.rb
@@ -196,6 +196,14 @@ describe Thumbor::CryptoURL, "#url_for" do
 
         url.should == image_md5
     end
+
+    it "should escape the URL used for a watermark" do
+        crypto = Thumbor::CryptoURL.new key
+
+        watermark_url = "http://my.domain.com/some/image/url.jpg?center=37.77,-122.412"
+        url = crypto.url_for :image => image_url, :filters => [[:watermark, watermark_url + ",1,2,3"]]
+        url.should include("#{CGI::escape(watermark_url) + ',1,2,3'}")
+    end
 end
 
 describe Thumbor::CryptoURL, "#generate" do


### PR DESCRIPTION
I make heavy use of the watermark filter in my codebase that uses Thumbor. As I brought up in [Thumbor issue #99](https://github.com/globocom/thumbor/issues/99) the image URLs used for the watermarks can contain trouble characters like commas and question marks with GET params after them. The solution proposed is to URL encode these characters to prevent interference with the containing URL.

As a result, now anytime I pass a URL to the watermark filter, I encode it first. A simple version of my code looks like this:

```
crypto = Thumbor::CryptoURL.new('secret_key')
crypto.generate({
  :width => width,
  :height => height,
  :image => source,
  :filters => "watermark:#{CGI::escape('http://my.domain.com/some/image.url.jpg?123456'),1,2,3"
})
```

Since I am forced to do this for every single URL that I use in a filter, it strikes me that this is something ruby-thumbor could, and maybe should, do for me. I am starting a thread here to discuss it. To make the proposal more concrete I also spiked on a possible implementation which is attached to this pull request.

In the code, I am liberally escaping the entire URL. If only escaping a subset of characters is necessary (e.g. ?, &, comma) then that would be more desirable.

You'll notice I am using an ugly regex to extract the 4 options for the watermark filter. The API for specifying a watermark filter is awfully janky in my opinion. The filter requires 4 options (url, x, y, alpha) and joining them together with commas and passing it all together as a single string is something I might expect to do when communicating over HTTP but not with a ruby library. The single string is prohibitive to work with for both the end-user and the library's developers. I believe that with a better API, the task of adding CGI::escape to the URL would have resulted in a cleaner patch.

Again, I am not expecting this pull request to get merged right away but I would like to get your thoughts on whether ruby-thumbor should take responsibility for escaping watermark urls.
