### PR TITLE
Fixing constructor call on README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,7 +28,7 @@ No dependencies required for regular usage.
 
     require 'ruby-thumbor'
 
-    crypto = Thumbor::CryptoURL.new :key => 'my-security-key'
+    crypto = Thumbor::CryptoURL.new 'my-security-key'
 
     url = crypto.generate :width => 200, :height => 300, :image => 'my.server.com/path/to/image.jpg'
 


### PR DESCRIPTION
The constructor call on README.rdoc was broken. Follows the stack trace.

11:42 ~/Hacks/ruby-thumbor (master) 
$ irb
1.9.2-p320 :001 > require "ruby-thumbor"
 => false 
1.9.2-p320 :002 > Thumbor::CryptoURL.new :key => 'teste'  
NoMethodError: undefined method `*' for {:key=>"teste"}:Hash
    from /home/u0000271/.rvm/gems/ruby-1.9.2-p320@rubythumbor/gems/ruby-thumbor-1.1.0/lib/thumbor/crypto_url.rb:12:in`initialize'
    from (irb):2:in `new'
    from (irb):2
    from /home/u0000271/.rvm/rubies/ruby-1.9.2-p320/bin/irb:16:in`<main>'
1.9.2-p320 :003 > 
