### PR TITLE
Fix URL generation when there are no image manipulations specified

### DIFF
--- a/lib/thumbor/crypto_url.rb
+++ b/lib/thumbor/crypto_url.rb
@@ -129,13 +129,17 @@ module Thumbor
         end
 
         def generate_new(options)
-            url_options = url_for(options, false)
-            url = "#{url_options}/#{options[:image]}"
+            thumbor_path = ""
 
-            signature = OpenSSL::HMAC.digest('sha1', Thumbor.key, url)
-            signature = url_safe_base64(signature)
+            image_options = url_for(options, false)
+            thumbor_path << image_options + '/' unless image_options.empty?
 
-            "/#{signature}/#{url}"
+            thumbor_path << options[:image]
+
+            signature = url_safe_base64(OpenSSL::HMAC.digest('sha1', Thumbor.key, thumbor_path))
+            thumbor_path.insert(0, "/#{signature}/")
+
+            thumbor_path
         end
 
         def generate(options)

--- a/spec/thumbor/crypto_url_spec.rb
+++ b/spec/thumbor/crypto_url_spec.rb
@@ -144,6 +144,11 @@ describe Thumbor::CryptoURL do
   end
 
   describe '#generate' do
+    it "should generate a proper url when only an image url is specified" do
+      url = subject.generate :image => image_url
+
+      url.should == "/964rCTkAEDtvjy_a572k7kRa0SU=/#{image_url}"
+    end
 
     it "should create a new instance passing key and keep it" do
       url = subject.generate :width => 300, :height => 200, :image => image_url


### PR DESCRIPTION
Without this patch the URL ruby-thumbor generates has one too many slashes after the signature.

Example of bad url before patch: /Tp9ufQVWNLVkNOwv6zXu5k2oFkc=//my.domain.com/some/image/url.jpg
Example of good url after patch: /964rCTkAEDtvjy_a572k7kRa0SU=/my.domain.com/some/image/url.jpg
