### PR TITLE
moved :trim option to the first part of the URL

### DIFF
--- a/lib/thumbor/crypto_url.rb
+++ b/lib/thumbor/crypto_url.rb
@@ -136,6 +136,12 @@ module Thumbor
 
             url_parts = Array.new
 
+            if options[:trim]
+                trim_options  = ['trim']
+                trim_options << options[:trim] unless options[:trim] == true or options[:trim][0] == true
+                url_parts.push(trim_options.join(':'))
+            end
+
             if options[:meta]
                 url_parts.push('meta')
             end
@@ -170,12 +176,6 @@ module Thumbor
 
             if options[:smart]
                 url_parts.push('smart')
-            end
-
-            if options[:trim]
-                trim_options  = ['trim']
-                trim_options << options[:trim] unless options[:trim] == true or options[:trim][0] == true
-                url_parts.push(trim_options.join(':'))
             end
 
             if options[:filters] && !options[:filters].empty?


### PR DESCRIPTION
The URL generated when the :trim option was set was invalid since it had the /trim/ argument after the image size.

Moved it to the begining of the URL according to
https://github.com/globocom/thumbor/wiki/Usage#trim
