### PR TITLE
CryptoUrl#url_for should never mutate its arguments

### DIFF
--- a/lib/thumbor/crypto_url.rb
+++ b/lib/thumbor/crypto_url.rb
@@ -46,11 +46,7 @@ module Thumbor
                 width = '0' if not has_width and not options[:flip]
             end
 
-            if width or height
-                width = width.to_s
-                height = height.to_s
-                url_parts.push(width << 'x' << height)
-            end
+            url_parts.push("#{width}x#{height}") if width || height
         end
 
         def calculate_centered_crop(options)

--- a/spec/thumbor/crypto_url_spec.rb
+++ b/spec/thumbor/crypto_url_spec.rb
@@ -227,6 +227,17 @@ describe Thumbor::CryptoURL do
       url = subject.url_for :image => image_url, :original_width => 100, :original_height => 100, :width => -50, :height => -40, :center => [50, 50]
       expect(url).to eq('0x10:100x90/-50x-40/' << image_md5)
     end
+
+    it "should handle string values" do
+      url = subject.url_for :image => image_url, :width => '40', :height => '50'
+      expect(url).to eq('40x50/' << image_md5)
+    end
+
+    it "should never mutate its arguments" do
+      opts = {:image => image_url, :width => '500'}
+      subject.url_for opts
+      expect(opts).to eq({:image => image_url, :width => '500'})
+    end
   end
 
   describe '#generate' do


### PR DESCRIPTION
Fixes a subtle bug, and this rewrite is idiomatic ruby.

Whether or not string values should be accepted is debatable, but as long as they are, we should take care to not corrupt existing variables.