### PR TITLE
Remove warnings

### DIFF
--- a/lib/thumbor/crypto_url.rb
+++ b/lib/thumbor/crypto_url.rb
@@ -5,7 +5,7 @@ require 'cgi'
 
 module Thumbor
     class CryptoURL
-        attr_accessor :computed_key
+        attr_writer :computed_key
 
         def initialize(key=false)
             @key = key


### PR DESCRIPTION
A simple change to avoid boring warnings:

Running tests with `RUBYOPT=-w` before the changes:

```
Ruby Warnings found:
   1 lib/thumbor/crypto_url.rb:14: warning: method redefined; discarding old computed_key
```